### PR TITLE
Remove regex bug in self.get_latest_version

### DIFF
--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
   end
 
   def self.get_latest_version(origin)
-    if latest_version = self.get_version_list.lines.find { |l| l =~ /^#{origin} +/ }
+    if latest_version = self.get_version_list.lines.find { |l| l =~ /^#{origin} / }
       latest_version = latest_version.split(' ').last.split(')').first
       return latest_version
     end

--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
   end
 
   def self.get_latest_version(origin)
-    if latest_version = self.get_version_list.lines.find { |l| l =~ /^#{origin}/ }
+    if latest_version = self.get_version_list.lines.find { |l| l =~ /^#{origin} +/ }
       latest_version = latest_version.split(' ').last.split(')').first
       return latest_version
     end

--- a/spec/fixtures/pkg.version
+++ b/spec/fixtures/pkg.version
@@ -1,2 +1,3 @@
+shells/bash-completion             <   needs updating (index has 2.1_3)
 ftp/curl                           <   needs updating (index has 7.33.0_2)
 shells/zsh                         <   needs updating (index has 5.0.4)

--- a/spec/fixtures/pkg.version
+++ b/spec/fixtures/pkg.version
@@ -1,3 +1,3 @@
-shells/bash-completion             <   needs updating (index has 2.1_3)
 ftp/curl                           <   needs updating (index has 7.33.0_2)
+shells/bash-completion             <   needs updating (index has 2.1_3)
 shells/zsh                         <   needs updating (index has 5.0.4)

--- a/spec/unit/puppet/provider/pkgng_spec.rb
+++ b/spec/unit/puppet/provider/pkgng_spec.rb
@@ -146,5 +146,13 @@ describe provider_class do
       nmap_latest_version = provider_class.get_latest_version('security/nmap')
       nmap_latest_version.should be_nil
     end
+
+    it "should match the package name exactly" do
+      bash_comp_latest_version = provider_class.get_latest_version('shells/bash-completion')
+      bash_comp_latest_version.should == "2.1_3"
+
+      bash_latest_version = provider_class.get_latest_version('shells/bash')
+      bash_latest_version.should be_nil
+    end
   end
 end


### PR DESCRIPTION
Theoretically, you can match the wrong port.

For example:
I call self.get_latest_version("shells/bash") and bash is up to date.  However, shells/bash-completion is not.  Puppet will try to update bash to bash-completion's latest version.