### PR TITLE
Add DragonFlyBSD to the list of operating systems to use pkgng by default

### DIFF
--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
   confine :operatingsystem => [:freebsd, :dragonfly]
   confine :pkgng_enabled => :true
 
-  defaultfor :operatingsystem => :freebsd
+  defaultfor :operatingsystem => [:freebsd, :dragonfly]
   defaultfor :pkgng_enabled => :true
 
 


### PR DESCRIPTION
This should be the default for DragonFlyBSD just as it is FreeBSD. At this point, no one should be using DragonFly < 3.4, and everything since uses pkgng exclusively. The other parts of the fact have the correct logic in them.