### PR TITLE
Cache the results to ensure a single version qeury

### DIFF
--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
   end
 
   def self.get_version_list
-    pkg(['version', '-voRL='])
+    @version_info_list ||= pkg(['version', '-voRL='])
   end
 
   def self.get_latest_version(origin)


### PR DESCRIPTION
Without this change, 'pkg version' is called once for each package found
on the system to determine if it is the latest version.  As a result of
using the '-R' flag, this reaches out to the repositories for this
information once for each package, which can contribute considerably to
the total run of the agent.

Here we cache the results of the initial query in a class variable to
ensure that only one request is made to retrieve the full list of
version information for all discovered packages.