### PR TITLE
Added signature_type support

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -4,15 +4,15 @@
 # better.
 
 define pkgng::repo (
-    $packagehost	= $name,
-    $protocol		= 'http',
-    $mirror_type	= 'srv',
-    $repopath		= '/${ABI}/latest',
-    $enabled		= true,
-    $priority		= 0,
-    $signature_type	= '',
-    $pubkey		= '',
-    $fingerprints	= '',
+    $packagehost  = $name,
+    $protocol    = 'http',
+    $mirror_type  = 'srv',
+    $repopath    = '/${ABI}/latest',
+    $enabled    = true,
+    $priority    = 0,
+    $signature_type  = '',
+    $pubkey    = '',
+    $fingerprints  = '',
 ) {
   include ::pkgng
 
@@ -44,15 +44,15 @@ define pkgng::repo (
   validate_string($signature_type)
   validate_absolute_path($pubkey)
 
-  if ($pubkey != "") {
-        if ($signature_type != "" and $signature_type !~ /(?ix:pubkey)/) {
-	    fail("Signature_type should be \"pubkey\"!")
-	}
+  if ($pubkey != '') {
+        if ($signature_type != '' and $signature_type !~ /(?ix:pubkey)/) {
+      fail("Signature_type should be \"pubkey\"!")
   }
-  if ($fingerprints != "") {
-        if ($signature_type != "" and $signature_type !~ /(?ix:fingerprints)/) {
-	    fail("Signature_type should be \"fingerprints\"!")
-	}
+  }
+  if ($fingerprints != '') {
+        if ($signature_type != '' and $signature_type !~ /(?ix:fingerprints)/) {
+      fail("Signature_type should be \"fingerprints\"!")
+  }
   }
 
   # define repository configuration

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -4,12 +4,15 @@
 # better.
 
 define pkgng::repo (
-    $packagehost = $name,
-    $protocol    = 'http',
-    $mirror_type = 'srv',
-    $repopath    = '/${ABI}/latest',
-    $enabled     = true,
-    $priority    = 0,
+    $packagehost	= $name,
+    $protocol		= 'http',
+    $mirror_type	= 'srv',
+    $repopath		= '/${ABI}/latest',
+    $enabled		= true,
+    $priority		= 0,
+    $signature_type	= '',
+    $pubkey		= '',
+    $fingerprints	= '',
 ) {
   include ::pkgng
 
@@ -37,6 +40,20 @@ define pkgng::repo (
     validate_bool($enabled)
   }
   validate_integer($priority, 100)
+
+  validate_string($signature_type)
+  validate_absolute_path($pubkey)
+
+  if ($pubkey != "") {
+        if ($signature_type != "" and $signature_type !~ /(?ix:pubkey)/) {
+	    fail("Signature_type should be \"pubkey\"!")
+	}
+  }
+  if ($fingerprints != "") {
+        if ($signature_type != "" and $signature_type !~ /(?ix:fingerprints)/) {
+	    fail("Signature_type should be \"fingerprints\"!")
+	}
+  }
 
   # define repository configuration
   file { "/usr/local/etc/pkg/repos/${name}.conf":

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -39,7 +39,7 @@ define pkgng::repo (
   } else {
     validate_bool($enabled)
   }
-  validate_integer($priority, 100)
+  validate_integer($priority, undef, 0)
 
   validate_string($signature_type)
   validate_absolute_path($pubkey)

--- a/templates/repo.erb
+++ b/templates/repo.erb
@@ -3,10 +3,10 @@
 <%= @name -%>: {
     url:		"<% if @mirror_type =~ /srv/i %>pkg+<% end %><%= @protocol %>://<%= @packagehost %><%= @repopath %>",
     mirror_type:	"<%= @mirror_type %>",
-    enabled:		"<% if @enabled == true or @enabled == 'yes' %>yes<% else %>no<% end %>",
-    priority:		"<%= @priority %>"
-    <% if @pubkey != ''  %>pubkey:		"<%= @pubkey %>"
-    signature_type:	"pubkey"<% end %>
-    <% if @fingerprints != ''  %>fingerprints:		"<%= @fingerprints %>"
+    enabled:		<% if @enabled == true or @enabled == 'yes' %>yes<% else %>no<% end %>,
+    priority:		<%= @priority %>,
+    <% if @pubkey != ''  %>pubkey:		"<%= @pubkey %>",
+    signature_type:	"pubkey",<% end %>
+    <% if @fingerprints != ''  %>fingerprints:		"<%= @fingerprints %>",
     signature_type:	"fingerprints"<% end %>
 }

--- a/templates/repo.erb
+++ b/templates/repo.erb
@@ -4,9 +4,15 @@
     url:		"<% if @mirror_type =~ /srv/i %>pkg+<% end %><%= @protocol %>://<%= @packagehost %><%= @repopath %>",
     mirror_type:	"<%= @mirror_type %>",
     enabled:		<% if @enabled == true or @enabled == 'yes' %>yes<% else %>no<% end %>,
+    <%- if @priority != 0 -%>
     priority:		<%= @priority %>,
-    <% if @pubkey != ''  %>pubkey:		"<%= @pubkey %>",
-    signature_type:	"pubkey"<% end %>
-    <% if @fingerprints != ''  %>fingerprints:		"<%= @fingerprints %>",
-    signature_type:	"fingerprints"<% end %>
+    <%- end -%>
+    <%- if @pubkey != '' -%>
+    pubkey:		"<%= @pubkey %>",
+    signature_type:	"pubkey"
+    <%- end -%>
+    <%- if @fingerprints != '' -%>
+    fingerprints:	"<%= @fingerprints %>",
+    signature_type:	"fingerprints"
+    <% end -%>
 }

--- a/templates/repo.erb
+++ b/templates/repo.erb
@@ -1,8 +1,12 @@
 # File managed by Puppet
 
 <%= @name -%>: {
-    url:         "<% if @mirror_type =~ /srv/i %>pkg+<% end %><%= @protocol %>://<%= @packagehost %><%= @repopath %>",
-    mirror_type: "<%= @mirror_type %>",
-    enabled:     <% if @enabled == true or @enabled == 'yes' %>yes<% else %>no<% end %>,
-    priority:    <%= @priority %>
+    url:		"<% if @mirror_type =~ /srv/i %>pkg+<% end %><%= @protocol %>://<%= @packagehost %><%= @repopath %>",
+    mirror_type:	"<%= @mirror_type %>",
+    enabled:		"<% if @enabled == true or @enabled == 'yes' %>yes<% else %>no<% end %>",
+    priority:		"<%= @priority %>"
+    <% if @pubkey != ''  %>pubkey:		"<%= @pubkey %>"
+    signature_type:	"pubkey"<% end %>
+    <% if @fingerprints != ''  %>fingerprints:		"<%= @fingerprints %>"
+    signature_type:	"fingerprints"<% end %>
 }

--- a/templates/repo.erb
+++ b/templates/repo.erb
@@ -6,7 +6,7 @@
     enabled:		<% if @enabled == true or @enabled == 'yes' %>yes<% else %>no<% end %>,
     priority:		<%= @priority %>,
     <% if @pubkey != ''  %>pubkey:		"<%= @pubkey %>",
-    signature_type:	"pubkey",<% end %>
+    signature_type:	"pubkey"<% end %>
     <% if @fingerprints != ''  %>fingerprints:		"<%= @fingerprints %>",
     signature_type:	"fingerprints"<% end %>
 }


### PR DESCRIPTION
I added initial support of signature repository.
I'm a newbie in ruby, so my code are far for ideal, I'm afraid, so check it before.

Usage example:
```
class repository {
    if ($operatingsystem == "FreeBSD") {
        if ($operatingsystemmajrelease * 1) == 10 {
        pkgng::repo { 'smart':
            packagehost => 'pkg.smartspb.net',
            repopath => '/packages/101amd64',
            protocol => "http",
            mirror_type => "http",
            pubkey => "/usr/local/etc/pkg/repos/smart.cert",
            priority => 100 }
        }
        file {'smart.cert':
                ensure  => file,
                path    => '/usr/local/etc/pkg/repos/smart.cert',
                owner   => root,
                group   => wheel,
                mode    => "0644",
                source  => "puppet:///files/others/pkg/smart.cert",
                purge   => true,
        }
    }
}
```
Result:

*cat /usr/local/etc/pkg/repos/smart.conf*
```
# File managed by Puppet

smart: {
    url:                "http://pkg.smartspb.net/packages/101amd64",
    mirror_type:        "http",
    enabled:            yes,
    priority:           100,
    pubkey:             "/usr/local/etc/pkg/repos/smart.cert",
    signature_type:     "pubkey"
}
```
