### PR TITLE
Pull in updates from upstream

### DIFF
--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -17,11 +17,11 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
   end
 
   def self.get_version_list
-    @version_info_list ||= pkg(['version', '-voRL='])
+    pkg(['version', '-voRL='])
   end
 
-  def self.get_latest_version(origin)
-    if latest_version = self.get_version_list.lines.find { |l| l =~ /^#{origin} / }
+  def self.get_latest_version(origin, version_list)
+    if latest_version = version_list.lines.find { |l| l =~ /^#{origin} / }
       latest_version = latest_version.split(' ').last.split(')').first
       return latest_version
     end
@@ -32,6 +32,7 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
     packages = []
     begin
       info = self.get_query
+      version_list = self.get_version_list
 
       unless info
         return packages
@@ -40,7 +41,7 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
       info.lines.each do |line|
 
         name, version, origin = line.chomp.split(" ", 3)
-        latest_version  = get_latest_version(origin) || version
+        latest_version  = get_latest_version(origin, version_list) || version
 
         pkg = {
           :ensure   => version,
@@ -83,16 +84,16 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
     case resource[:ensure]
     when true, false, Symbol
       installname = resource[:name]
+    else
+      # If resource[:name] is actually an origin (e.g. 'www/curl' instead of
+      # just 'curl'), drop the category prefix. pkgng doesn't support version
+      # pinning with the origin syntax (pkg install curl-1.2.3 is valid, but
+      # pkg install www/curl-1.2.3 is not).
+      if resource[:name] =~ /\//
+        installname = resource[:name].split('/')[1] + '-' + resource[:ensure]
       else
-        # If resource[:name] is actually an origin (e.g. 'www/curl' instead of
-        # just 'curl'), drop the category prefix. pkgng doesn't support version
-        # pinning with the origin syntax (pkg install curl-1.2.3 is valid, but
-        # pkg install www/curl-1.2.3 is not).
-        if resource[:name] =~ /\//
-          installname = resource[:name].split('/')[1] + '-' + resource[:ensure]
-        else
-          installname = resource[:name] + '-' + resource[:ensure]
-        end
+        installname = resource[:name] + '-' + resource[:ensure]
+      end
     end
 
     if not source # install using default repo logic

--- a/spec/unit/puppet/provider/pkgng_spec.rb
+++ b/spec/unit/puppet/provider/pkgng_spec.rb
@@ -154,15 +154,17 @@ describe provider_class do
 
   describe "get_latest_version" do
     it "should rereturn nil when the current package is the latest" do
-      nmap_latest_version = provider_class.get_latest_version('security/nmap')
+      version_list = File.read('spec/fixtures/pkg.version')
+      nmap_latest_version = provider_class.get_latest_version('security/nmap', version_list)
       expect(nmap_latest_version).to be_nil
     end
 
     it "should match the package name exactly" do
-      bash_comp_latest_version = provider_class.get_latest_version('shells/bash-completion')
+      version_list = File.read('spec/fixtures/pkg.version')
+      bash_comp_latest_version = provider_class.get_latest_version('shells/bash-completion', version_list)
       expect(bash_comp_latest_version).to eq("2.1_3")
 
-      bash_latest_version = provider_class.get_latest_version('shells/bash')
+      bash_latest_version = provider_class.get_latest_version('shells/bash', version_list)
       expect(bash_latest_version).to be_nil
     end
   end


### PR DESCRIPTION
This work is the results of what has been merged upstream into core.
Here we align what the module delivers compared to what is available in
the latest version of puppet 4 in preparation of removing the provider
from this repository entirely.