### PR TITLE
Drop legacy code

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,34 +61,11 @@ class pkgng (
     ensure => directory,
   }
 
-  file { '/etc/make.conf':
-    ensure => present,
-  }
-
-  file_line { 'WITH_PKGNG':
-    path    => '/etc/make.conf',
-    line    => "WITH_PKGNG=yes\n",
-    require => File['/etc/make.conf'],
-  }
-
   # Triggered on config changes
   exec { 'pkg update':
     path        => '/usr/local/sbin',
     refreshonly => true,
     command     => 'pkg update -q -f',
-  }
-
-  # This exec should really on ever be run once, and only upon converting to
-  # pkgng. If you are building up a new system where the only software that
-  # has been installed form ports is the pkgng itself, then the pkg database
-  # is already up to date, and this is not required. As you will see,
-  # refreshonly, but nothing notifies this. I am uncertain at this time how
-  # to proceed, other than manually.
-  exec { 'convert pkg database to pkgng':
-    path        => '/usr/local/sbin',
-    refreshonly => true,
-    command     => 'pkg2ng',
-    require     => File['/etc/make.conf'],
   }
 
   # expand all pkg repositories from hashtable


### PR DESCRIPTION
WITH_PKGNG=yes was required for FreeBSD versions earlier than 10.x, and
this module supports FreeBSD 10 or 11, see:
https://www.freebsd.org/doc/handbook/pkgng-intro.html#pkgng-initial-setup

Likewisely, pkg2ng was needed for switching to pkg, which does not look
like a responsibility for a configuration management system like puppet
but for an orchestration system like MCollective.  It was unused by the
way.