### PR TITLE
Do not erase /etc/pkg/FreeBSD.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,17 @@ class { 'pkgng':
 }
 ```
 
-By default, this module will erase the default repository and you'll want to
-define some. To disable this behaviour you can use the example above of
+By default, this module will erase user-defined repository not managed by Puppet.
+To disable this behaviour you can use the example above of
 setting `purge_repos_d` to false.
+
+Disabling the FreeBSD default repository is done with:
+
+```Puppet
+pkgng::repo { 'FreeBSD':
+  enabled => false,
+}
+```
 
 Using specific repositories is as simple as a Puppet resource.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,22 +43,10 @@ class pkgng (
     ensure => directory,
   }
 
-  if $purge_repos_d == true {
-    File['/usr/local/etc/pkg/repos'] {
-      recurse => true,
-      purge   => true,
-    }
-
-    file { '/etc/pkg':
-      ensure  => directory,
-      purge   => true,
-      recurse => true,
-      before  => Exec['pkg update'],
-    }
-  }
-
   file { '/usr/local/etc/pkg/repos':
-    ensure => directory,
+    ensure  => directory,
+    recurse => true,
+    purge   => $purge_repos_d,
   }
 
   file { '/etc/make.conf':

--- a/spec/classes/pkgng_spec.rb
+++ b/spec/classes/pkgng_spec.rb
@@ -7,7 +7,6 @@ describe 'pkgng' do
 
       it { is_expected.to contain_class('pkgng') }
       it { is_expected.to contain_class('pkgng::params') }
-      it { is_expected.to contain_file('/etc/pkg').with(ensure: 'directory') }
       it { is_expected.to contain_file('/usr/local/etc/pkg').with(ensure: 'directory') }
       it { is_expected.to contain_file('/usr/local/etc/pkg/repos').with(ensure: 'directory') }
       it { is_expected.to contain_file('/usr/local/etc/pkg.conf') }


### PR DESCRIPTION
Erasing this file was unexpected, and is probably a bad idea since it is
part of the base system and `freebsd-update(8)` may want to update it.

According to `pkg.conf(5)`:

```
     The repository tag	myrepo is an arbitrary string.	Reusing	the repository
     tag will cause those items	defined	in configuration files later on	the
     REPOS_DIR search path to overwrite	the equivalent settings	for the	same
     tag earlier on the	search path.  Hence the	very common idiom, used	to
     turn off the default FreeBSD configuration	shipped	in
     /etc/pkg/FreeBSD.conf.  Rather than editing that file directly, create
     /usr/local/etc/pkg/repos/FreeBSD.conf with	this content:

	   FreeBSD: { enabled: NO }
```

So, ask to do this way in the README and only purge the user defined
repositories that are not managed by Puppet, following the
recommendations of the man page.

:warning:  Since this change the behavior of the module, I guess a major version bump would be required.