### PR TITLE
Add facts to report outdated / vulnerable packages

### DIFF
--- a/lib/facter/pkg_updates.rb
+++ b/lib/facter/pkg_updates.rb
@@ -1,0 +1,66 @@
+pkg_package_updates = []
+pkg_package_vulnerables = []
+
+Facter.add('pkg_has_updates') do
+  confine osfamily: 'FreeBSD'
+  setcode do
+    if File.executable?('/usr/sbin/pkg')
+      pkg_version_result = Facter::Util::Resolution.exec('/usr/sbin/pkg version -ql"<"')
+      unless pkg_version_result.nil?
+        pkg_version_result.each_line do |line|
+          package = line.split.first
+          pkg_package_updates.push(package)
+        end
+      end
+    end
+
+    pkg_package_updates.any?
+  end
+end
+
+Facter.add('pkg_updates') do
+  confine pkg_has_updates: true
+  setcode do
+    Integer(pkg_package_updates.length)
+  end
+end
+
+Facter.add('pkg_package_updates') do
+  confine pkg_has_updates: true
+  setcode do
+    if Facter.version < '2.0.0'
+      pkg_package_updates.join(',')
+    else
+      pkg_package_updates
+    end
+  end
+end
+
+Facter.add('pkg_has_vulnerabilities') do
+  confine osfamily: 'FreeBSD'
+  setcode do
+    if File.executable?('/usr/sbin/pkg')
+      pkg_package_vulnerables = Facter::Util::Resolution.exec('/usr/sbin/pkg audit -q').split.map(&:chomp)
+    end
+
+    pkg_package_vulnerables.any?
+  end
+end
+
+Facter.add('pkg_vulnerabilities') do
+  confine pkg_has_vulnerabilities: true
+  setcode do
+    Integer(pkg_package_vulnerables.count)
+  end
+end
+
+Facter.add('pkg_package_vulnerables') do
+  confine pkg_has_vulnerabilities: true
+  setcode do
+    if Facter.version < '2.0.0'
+      pkg_package_vulnerables.join(',')
+    else
+      pkg_package_vulnerables
+    end
+  end
+end

--- a/lib/facter/pkg_updates.rb
+++ b/lib/facter/pkg_updates.rb
@@ -54,7 +54,7 @@ Facter.add('pkg_vulnerabilities') do
   end
 end
 
-Facter.add('pkg_package_vulnerables') do
+Facter.add('pkg_vulnerable_packages') do
   confine pkg_has_vulnerabilities: true
   setcode do
     if Facter.version < '2.0.0'

--- a/spec/unit/facter/pkg_has_updates_spec.rb
+++ b/spec/unit/facter/pkg_has_updates_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'pkg_has_updates fact' do
+  subject { Facter.fact(:pkg_has_updates).value }
+  after { Facter.clear }
+
+  before { Facter.fact(:osfamily).expects(:value).returns(osfamily) }
+
+  context 'on non FreeBSD host' do
+    let(:osfamily) { 'Debian' }
+    it { is_expected.to be_nil }
+  end
+
+  context 'on FreeBSD host' do
+    let(:osfamily) { 'FreeBSD' }
+    before do
+      File.stubs(:executable?)
+      File.expects(:executable?).with('/usr/sbin/pkg').returns true
+      Facter::Util::Resolution.expects(:exec).with('/usr/sbin/pkg version -ql"<"').returns(pkg_version_output)
+    end
+    context 'without package updates' do
+      let(:pkg_version_output) { '' }
+      it { is_expected.to be false }
+    end
+    context 'with package updates' do
+      let(:pkg_version_output) { "apr-1.6.2.1.6.0\napache24-2.4.27\n" }
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/unit/facter/pkg_has_vulnerabilities_spec.rb
+++ b/spec/unit/facter/pkg_has_vulnerabilities_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'pkg_has_vulnerabilities fact' do
+  subject { Facter.fact(:pkg_has_vulnerabilities).value }
+  after { Facter.clear }
+
+  before { Facter.fact(:osfamily).expects(:value).returns(osfamily) }
+
+  context 'on non FreeBSD host' do
+    let(:osfamily) { 'Debian' }
+    it { is_expected.to be_nil }
+  end
+
+  context 'on FreeBSD host' do
+    let(:osfamily) { 'FreeBSD' }
+    before do
+      File.stubs(:executable?)
+      File.expects(:executable?).with('/usr/sbin/pkg').returns true
+      Facter::Util::Resolution.expects(:exec).with('/usr/sbin/pkg audit -q').returns(pkg_audit_output)
+    end
+    context 'without package vulnerabilities' do
+      let(:pkg_audit_output) { '' }
+      it { is_expected.to be false }
+    end
+    context 'with package vulnerabilities' do
+      let(:pkg_audit_output) { "apr-1.6.2.1.6.0\napache24-2.4.27\n" }
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/unit/facter/pkg_package_updates_spec.rb
+++ b/spec/unit/facter/pkg_package_updates_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'pkg_package_updates fact' do
+  subject { Facter.fact(:pkg_package_updates).value }
+  after { Facter.clear }
+
+  before do
+    File.stubs(:executable?)
+    Facter.fact(:osfamily).expects(:value).returns 'FreeBSD'
+    File.expects(:executable?).with('/usr/sbin/pkg').returns true
+    Facter::Util::Resolution.expects(:exec).with('/usr/sbin/pkg version -ql"<"').returns(pkg_version_output)
+  end
+
+  context 'when there is no update' do
+    let(:pkg_version_output) { '' }
+    it { is_expected.to be nil }
+  end
+
+  context 'when there are updates' do
+    let(:pkg_version_output) { "apr-1.6.2.1.6.0\napache24-2.4.27\n" }
+    if Facter.version < '2.0.0'
+      it { is_expected.to eq('apr-1.6.2.1.6.0,apache24-2.4.27') }
+    else
+      it { is_expected.to eq(['apr-1.6.2.1.6.0', 'apache24-2.4.27']) }
+    end
+  end
+end

--- a/spec/unit/facter/pkg_package_vulnerables_spec.rb
+++ b/spec/unit/facter/pkg_package_vulnerables_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'pkg_package_vulnerables fact' do
+  subject { Facter.fact(:pkg_package_vulnerables).value }
+  after { Facter.clear }
+
+  before do
+    File.stubs(:executable?)
+    Facter.fact(:osfamily).expects(:value).returns 'FreeBSD'
+    File.expects(:executable?).with('/usr/sbin/pkg').returns true
+    Facter::Util::Resolution.expects(:exec).with('/usr/sbin/pkg audit -q').returns(pkg_audit_output)
+  end
+
+  context 'when there is no update' do
+    let(:pkg_audit_output) { '' }
+    it { is_expected.to be nil }
+  end
+
+  context 'when there are updates' do
+    let(:pkg_audit_output) { "apr-1.6.2.1.6.0\napache24-2.4.27\n" }
+    if Facter.version < '2.0.0'
+      it { is_expected.to eq('apr-1.6.2.1.6.0,apache24-2.4.27') }
+    else
+      it { is_expected.to eq(['apr-1.6.2.1.6.0', 'apache24-2.4.27']) }
+    end
+  end
+end

--- a/spec/unit/facter/pkg_updates_spec.rb
+++ b/spec/unit/facter/pkg_updates_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'pkg_updates fact' do
+  subject { Facter.fact(:pkg_updates).value }
+  after { Facter.clear }
+
+  before do
+    File.stubs(:executable?)
+    Facter.fact(:osfamily).expects(:value).returns 'FreeBSD'
+    File.expects(:executable?).with('/usr/sbin/pkg').returns true
+    Facter::Util::Resolution.expects(:exec).with('/usr/sbin/pkg version -ql"<"').returns(pkg_version_output)
+  end
+
+  context 'when there is no update' do
+    let(:pkg_version_output) { '' }
+    it { is_expected.to be nil }
+  end
+
+  context 'when there are updates' do
+    let(:pkg_version_output) { "apr-1.6.2.1.6.0\napache24-2.4.27\n" }
+    it { is_expected.to eq(2) }
+  end
+end

--- a/spec/unit/facter/pkg_vulnerable_packages_spec.rb
+++ b/spec/unit/facter/pkg_vulnerable_packages_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-describe 'pkg_package_vulnerables fact' do
-  subject { Facter.fact(:pkg_package_vulnerables).value }
+describe 'pkg_vulnerable_packages fact' do
+  subject { Facter.fact(:pkg_vulnerable_packages).value }
   after { Facter.clear }
 
   before do

--- a/spec/unit/facter/pkg_vulnerables_spec.rb
+++ b/spec/unit/facter/pkg_vulnerables_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'pkg_vulnerabilities fact' do
+  subject { Facter.fact(:pkg_vulnerabilities).value }
+  after { Facter.clear }
+
+  before do
+    File.stubs(:executable?)
+    Facter.fact(:osfamily).expects(:value).returns 'FreeBSD'
+    File.expects(:executable?).with('/usr/sbin/pkg').returns true
+    Facter::Util::Resolution.expects(:exec).with('/usr/sbin/pkg audit -q').returns(pkg_audit_output)
+  end
+
+  context 'when there is no vulnerable packages' do
+    let(:pkg_audit_output) { '' }
+    it { is_expected.to be nil }
+  end
+
+  context 'when there are vulnerable packages' do
+    let(:pkg_audit_output) { "apr-1.6.2.1.6.0\napache24-2.4.27\n" }
+    it { is_expected.to eq(2) }
+  end
+end


### PR DESCRIPTION
When applicable, new facts where inspired by [pupeptlabs-apt's facts](https://github.com/puppetlabs/puppetlabs-apt/blob/master/lib/facter/apt_updates.rb):

  - `apt_has_updates`     -> `pkg_has_updates`     (`Boolean`)
  - `apt_updates`         -> `pkg_updates`         (`Integer`)
  - `apt_package_updates` -> `pkg_package_updates` (`Array[String]`)

Since `pkg-audit(8)` can report vulnerabilities in ports without updates, it's not possible to have a strict equivalent to `apt_security_updates`. So I created a bunch of facts to report vulnerable packages the same way outdated packages are reported:

  - `pkg_has_vulnerabilities` (`Boolean`)
  - `pkg_vulnerabilities`     (`Integer`)
  - `pkg_package_vulnerables` (`Array[String]`)

Sample output, on a system with 1 update and 2 vulnerable packages:

```
pkg_has_updates => true
pkg_has_vulnerabilities => true
pkg_package_updates => [
  "phantomjs-2.1.1"
]
pkg_package_vulnerables => [
  "OpenEXR-2.2.0_7",
  "oniguruma5-5.9.6_1"
]
pkg_updates => 1
pkg_vulnerabilities => 2
```

Sample output on a system up to date with no known vulnerabilities:

```
pkg_has_updates => false
pkg_has_vulnerabilities => false
```

:warning: Words and pluralization looks odd to me, but as a non-native English speaker, I could not find anything better (*vulnerable* vs. *vulnerabilities* vs. *with_vulnerabilities*) :confused:.  If you think some words are more suitable than these, please tell me and I'll update this pull-request!