### PR TITLE
Relax dependency on puppetlabs-stdlib

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -25,7 +25,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 5.0.0"
+      "version_requirement": ">= 4.6.0 < 6.0.0"
     }
   ]
 }


### PR DESCRIPTION
Fixes:

```
% puppet module list
Warning: Module 'puppetlabs-stdlib' (v5.1.0) fails to meet some dependencies:
  'zleslie-pkgng' (v2.1.1) requires 'puppetlabs-stdlib' (>= 4.6.0 < 5.0.0)
```