### PR TITLE
facter: always use the repository as a source of package version

### DIFF
--- a/lib/facter/pkg_updates.rb
+++ b/lib/facter/pkg_updates.rb
@@ -5,7 +5,7 @@ Facter.add('pkg_has_updates') do
   confine osfamily: 'FreeBSD'
   setcode do
     if File.executable?('/usr/sbin/pkg')
-      pkg_version_result = Facter::Util::Resolution.exec('/usr/sbin/pkg version -ql"<"')
+      pkg_version_result = Facter::Util::Resolution.exec('/usr/sbin/pkg version -RUql"<"')
       unless pkg_version_result.nil?
         pkg_version_result.each_line do |line|
           package = line.split.first

--- a/spec/unit/facter/pkg_has_updates_spec.rb
+++ b/spec/unit/facter/pkg_has_updates_spec.rb
@@ -16,7 +16,7 @@ describe 'pkg_has_updates fact' do
     before do
       File.stubs(:executable?)
       File.expects(:executable?).with('/usr/sbin/pkg').returns true
-      Facter::Util::Resolution.expects(:exec).with('/usr/sbin/pkg version -ql"<"').returns(pkg_version_output)
+      Facter::Util::Resolution.expects(:exec).with('/usr/sbin/pkg version -RUql"<"').returns(pkg_version_output)
     end
     context 'without package updates' do
       let(:pkg_version_output) { '' }

--- a/spec/unit/facter/pkg_package_updates_spec.rb
+++ b/spec/unit/facter/pkg_package_updates_spec.rb
@@ -8,7 +8,7 @@ describe 'pkg_package_updates fact' do
     File.stubs(:executable?)
     Facter.fact(:osfamily).expects(:value).returns 'FreeBSD'
     File.expects(:executable?).with('/usr/sbin/pkg').returns true
-    Facter::Util::Resolution.expects(:exec).with('/usr/sbin/pkg version -ql"<"').returns(pkg_version_output)
+    Facter::Util::Resolution.expects(:exec).with('/usr/sbin/pkg version -RUql"<"').returns(pkg_version_output)
   end
 
   context 'when there is no update' do

--- a/spec/unit/facter/pkg_updates_spec.rb
+++ b/spec/unit/facter/pkg_updates_spec.rb
@@ -8,7 +8,7 @@ describe 'pkg_updates fact' do
     File.stubs(:executable?)
     Facter.fact(:osfamily).expects(:value).returns 'FreeBSD'
     File.expects(:executable?).with('/usr/sbin/pkg').returns true
-    Facter::Util::Resolution.expects(:exec).with('/usr/sbin/pkg version -ql"<"').returns(pkg_version_output)
+    Facter::Util::Resolution.expects(:exec).with('/usr/sbin/pkg version -RUql"<"').returns(pkg_version_output)
   end
 
   context 'when there is no update' do


### PR DESCRIPTION
Using of ports tree (even with the presence of INDEX-XX) to determine outdated packages
is incredibly slow. In addition ports may have the updated version while pkg still not.
Since we work with pkg and not the ports we need to fix the source to repo

Fixes for issue #91